### PR TITLE
npm パッケージに README を含める

### DIFF
--- a/packages/fsss/package.json
+++ b/packages/fsss/package.json
@@ -30,6 +30,8 @@
     "dist"
   ],
   "scripts": {
+    "prepack": "cp ../../README.md .",
+    "postpack": "rm README.md",
     "prepare": "vite build",
     "build": "vite build",
     "dev": "vite build --watch",


### PR DESCRIPTION
## 概要

- `prepack`/`postpack` スクリプトでルートの `README.md` を npm パッケージに含めるようにする

## 背景

- モノレポ構成のため `README.md` はリポジトリルートにあるが、npm publish は `packages/fsss/` から実行されるため、npm ページに README が表示されなかった
- `prepack` でコピー → pack → `postpack` で削除する方式は、モノレポでの標準的なアプローチ（ [npm/rfcs Discussion #713](https://github.com/npm/rfcs/discussions/713) ）

## 変更内容

- `packages/fsss/package.json`: `prepack`（ルートから README をコピー）と `postpack`（コピーした README を削除）スクリプトを追加

## 確認事項

- [ ] `cd packages/fsss && pnpm pack` で生成された tarball に README.md が含まれること
- [ ] `postpack` 後に `packages/fsss/README.md` が残っていないこと