### PR TITLE
docs: README にプラグインセクション追加、比較表に gunshi 追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,4 @@
 - [設定ファイルと環境変数](config.md) — autoEnv、config ファイル階層、`--config` フラグ
 - [プラグインシステム](plugin.md) — `_plugins/` 規約、ミドルウェア、Extensions の型生成
 - [内部アーキテクチャ](architecture.md) — パイプライン設計、各モジュールの責務、処理トレース
-- [既存ツールとの比較](comparison.md) — commander / oclif / Pastel / Gud CLI / convict との比較
+- [既存ツールとの比較](comparison.md) — commander / oclif / Pastel / Gud CLI / gunshi / convict との比較

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,29 +2,30 @@
 
 ## 機能比較
 
-| 機能                            | fsss | commander | oclif  | Pastel              | Gud CLI | convict         |
-| ------------------------------- | ---- | --------- | ------ | ------------------- | ------- | --------------- |
-| ファイルベースルーティング      | ✓    | ✗         | ✓      | ✓                   | ✓       | —               |
-| 動的セグメント `[param]`        | ✓    | ✗         | ✗      | ✗                   | ✓       | —               |
-| Zod スキーマで引数定義          | ✓    | ✗         | ✗      | ✓                   | ✗       | ✗               |
-| 環境変数の統合                  | ✓    | ✗         | ✗      | ✗                   | ✗       | ✓               |
-| 設定ファイルの統合              | ✓    | ✗         | ✗      | ✗                   | ✗       | ✓               |
-| 1スキーマで CLI/env/config 統合 | ✓    | ✗         | ✗      | ✗                   | ✗       | ✗（Zod 非対応） |
-| params/args 分離                | ✓    | ✗         | ✗      | ✗                   | ✓       | —               |
-| ヘルプ自動生成                  | ✓    | ✓         | ✓      | ✓（commander 委譲） | ✗       | ✗               |
-| 型推論（defineCommand）         | ✓    | ✗         | 部分的 | ✗（手動 z.infer）   | 部分的  | ✗               |
-| bun ネイティブ                  | ✓    | ✗         | ✗      | ✗                   | ✗       | ✗               |
+| 機能                            | fsss | commander | oclif  | Pastel              | Gud CLI | gunshi                | convict         |
+| ------------------------------- | ---- | --------- | ------ | ------------------- | ------- | --------------------- | --------------- |
+| ファイルベースルーティング      | ✓    | ✗         | ✓      | ✓                   | ✓       | ✗                     | —               |
+| 動的セグメント `[param]`        | ✓    | ✗         | ✗      | ✗                   | ✓       | ✗                     | —               |
+| Zod スキーマで引数定義          | ✓    | ✗         | ✗      | ✓                   | ✗       | ✗                     | ✗               |
+| 環境変数の統合                  | ✓    | ✗         | ✗      | ✗                   | ✗       | ✗                     | ✓               |
+| 設定ファイルの統合              | ✓    | ✗         | ✗      | ✗                   | ✗       | ✗                     | ✓               |
+| 1スキーマで CLI/env/config 統合 | ✓    | ✗         | ✗      | ✗                   | ✗       | ✗                     | ✗（Zod 非対応） |
+| params/args 分離                | ✓    | ✗         | ✗      | ✗                   | ✓       | ✗                     | —               |
+| ヘルプ自動生成                  | ✓    | ✓         | ✓      | ✓（commander 委譲） | ✗       | ✓                     | ✗               |
+| プラグイン / ミドルウェア       | ✓    | ✗         | ✓      | ✗                   | ✓       | ✓                     | ✗               |
+| 型推論（defineCommand）         | ✓    | ✗         | 部分的 | ✗（手動 z.infer）   | 部分的  | ✓（defineWithTypes）  | ✗               |
+| bun ネイティブ                  | ✓    | ✗         | ✗      | ✗                   | ✗       | ✓（マルチランタイム） | ✗               |
 
 ## 実装比較
 
-| 観点           | fsss                   | oclif                | Pastel                   | Gud CLI                |
-| -------------- | ---------------------- | -------------------- | ------------------------ | ---------------------- |
-| コマンド発見   | `fs.readdir` 逐次      | `tinyglobby` glob    | `fs.readdir` 再帰        | `readdirSync` 逐次     |
-| データ構造     | 構築しない（逐次解決） | フラット Map         | 再帰 Map ツリー          | 構築しない（逐次解決） |
-| 引数パース     | 自前                   | 完全自前             | commander 委譲           | yargs-parser           |
-| バリデーション | Zod（1段階）           | 自前                 | commander + Zod（2段階） | yargs-parser のみ      |
-| 遅延ロード     | 逐次 import            | manifest + lazy load | なし（全ロード）         | 逐次 import            |
-| ランタイム依存 | zod のみ               | なし                 | React + Ink + commander  | yargs-parser           |
+| 観点           | fsss                   | oclif                | Pastel                   | Gud CLI                | gunshi                |
+| -------------- | ---------------------- | -------------------- | ------------------------ | ---------------------- | --------------------- |
+| コマンド発見   | `fs.readdir` 逐次      | `tinyglobby` glob    | `fs.readdir` 再帰        | `readdirSync` 逐次     | `subCommands` マップ  |
+| データ構造     | 構築しない（逐次解決） | フラット Map         | 再帰 Map ツリー          | 構築しない（逐次解決） | 手動定義マップ        |
+| 引数パース     | 自前                   | 完全自前             | commander 委譲           | yargs-parser           | args-tokens           |
+| バリデーション | Zod（1段階）           | 自前                 | commander + Zod（2段階） | yargs-parser のみ      | args-tokens           |
+| 遅延ロード     | 逐次 import            | manifest + lazy load | なし（全ロード）         | 逐次 import            | lazy（lazyWithTypes） |
+| ランタイム依存 | zod のみ               | なし                 | React + Ink + commander  | yargs-parser           | args-tokens のみ      |
 
 ## 各ツールの位置づけ
 
@@ -32,6 +33,7 @@
 - **oclif** — ファイルベースルーティングはあるが、env/config 統合なし。クラスベースで重厚
 - **Pastel** — Zod スキーマを採用しているが、React/Ink 必須。env/config 統合なし。`.describe()` に JSON を詰め込むハックがある
 - **Gud CLI** — ファイルベースルーティング + 動的セグメント + params/args 分離を実現しているが、Zod 非対応、env/config 統合なし
+- **gunshi** — プラグインシステム + 型推論 + マルチランタイム対応。ファイルベースルーティングや env/config 統合はなく、引数定義は args-tokens ベース
 - **convict** — CLI/env/config の統合はあるが、独自スキーマ形式で Zod 非対応。ファイルベースルーティングなし
 
 **fsss が目指すもの:** Gud CLI のルーティング設計（ファイルベース + 動的セグメント + params/args 分離）と、convict の設定統合思想（1スキーマで CLI/env/config を統一）を、Zod スキーマと bun の上で組み合わせる。どのツールも単独では持っていない「ファイルベースルーティング + Zod + CLI/env/config 統合」の3つを1つのフレームワークで提供する。
@@ -49,4 +51,5 @@ fsss の設計は Web フレームワークのメンタルモデルを CLI に�
 | `process.env`                  | `env`（環境変数）              |
 | `.env` + config                | 設定ファイル（JSON）           |
 | Zod でリクエストバリデーション | Zod で引数バリデーション       |
+| ミドルウェア（Express / Koa）  | `_plugins/` の middleware      |
 | OpenAPI / Swagger              | `--help` 自動生成              |


### PR DESCRIPTION
## 概要

PR #14 で追加されたプラグインシステムを README に反映し、比較表に gunshi を追加する。

## 背景

PR #14 でプラグインシステム（`_plugins/` ディレクトリ規約 + codegen 型生成）が実装されたが、ルート README.md には反映されていなかった。また、比較表にプラグイン/ミドルウェアの行がなく、gunshi も比較対象に含まれていなかった。

各ツールのプラグイン対応状況はリポジトリをクローンしてソースコードから調査した。

## 変更内容

- `README.md`: Plugin セクションを新規追加（`_plugins/` のツリー図、`definePlugin` コード例、`extensions` の使い方）
- `README.md`: ドキュメントリンク一覧にプラグインシステムを追加、見出しを `docs/README.md` へのリンクに変更
- `docs/comparison.md`: 機能比較表に「プラグイン / ミドルウェア」行を追加
- `docs/comparison.md`: gunshi 列を機能比較表・実装比較表・位置づけに追加
- `docs/comparison.md`: Web フレームワーク対比表にミドルウェア行を追加
- `docs/README.md`: 比較ドキュメントの説明文に gunshi を追加

## 確認事項

- [ ] README のプラグインセクションが `docs/plugin.md` の内容と整合しているか
- [ ] 比較表の各ツールの値が正確か（commander, oclif, Pastel, Gud CLI, gunshi, convict）