### PR TITLE
publish ワークフローで npm を pnpm に変更し catalog: を解決させる

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        run: npm publish --provenance --access public
+        run: pnpm publish --provenance --access public --no-git-checks
         working-directory: packages/fsss


### PR DESCRIPTION
## 概要

publish ワークフローの `npm publish` を `pnpm publish` に変更し、`catalog:` プロトコルが実バージョンに解決されるようにする。

## 背景

npm レジストリに公開された `@miyaoka/fsss` パッケージの `dependencies` に `"zod": "catalog:"` がそのまま残っていた。これは pnpm の catalog プロトコルであり、npm レジストリ経由でインストールするユーザーの環境では解決できない。

原因は publish ワークフローで `npm publish` を使用していたこと。`npm` は pnpm の `catalog:` プロトコルを認識しないため、変換されずにそのまま tarball に含まれていた。`pnpm publish` は publish 前に `catalog:` を `pnpm-workspace.yaml` の実バージョンに置換する。

## 変更内容

- `.github/workflows/publish.yml`: `npm publish` → `pnpm publish` に変更
- CI の detached HEAD 環境で pnpm の git チェックが失敗しないよう `--no-git-checks` を追加

## 確認事項

- [ ] `pnpm pack` でローカル生成した tarball の `package.json` で `"zod": "4.3.6"` に解決されていることを確認済み
- [ ] CI での publish 実行時に認証エラーが出ないか（`NODE_AUTH_TOKEN` の設定が必要になる可能性あり）