### PR TITLE
リリースノートから依存更新 PR を除外

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies


### PR DESCRIPTION
## 概要

自動生成リリースノートから `dependencies` ラベルの PR を除外する設定を追加します。

## 背景

v0.2.2 のリリースノートが Renovate による依存更新 PR で埋まり、実質的な変更が見づらい状態でした。`.github/release.yml` で除外設定を行うことで、今後のリリースノートには機能変更やバグ修正のみが表示されるようになります。

## 変更内容

- `.github/release.yml` を新規作成し、`dependencies` ラベルの PR をリリースノートから除外

## 確認事項

- [ ] 次回リリース時に Renovate PR がリリースノートから除外されていること