### PR TITLE
defaultCommand フォールバック時に未マッチトークンを位置引数として渡す

### DIFF
--- a/packages/fsss/src/cli.ts
+++ b/packages/fsss/src/cli.ts
@@ -127,11 +127,8 @@ function createCLI(options: CLIOptions): CLI {
     // ルート未解決時の処理
     if (routeResult.kind === "unresolved") {
       const isRootLevel = resolve(routeResult.stoppedDir) === resolve(commandsDir);
-      // 先頭トークンがコマンド名候補（フラグでない文字列）の場合、
-      // 存在しないコマンド名なので defaultCommand に fallback しない
-      const hasUnmatchedCommand = tokens.length > 0 && !tokens[0].startsWith("-");
 
-      if (isRootLevel && defaultCommand !== undefined && !hasUnmatchedCommand) {
+      if (isRootLevel && defaultCommand !== undefined) {
         // --help / -h → サブコマンド一覧 + デフォルトコマンドの Options を統合表示
         if (tokens.includes("--help") || tokens.includes("-h")) {
           const defaultRouteResult = await resolveRoute(commandsDir, [defaultCommand]);
@@ -162,8 +159,7 @@ function createCLI(options: CLIOptions): CLI {
         }
         routeResult = retryResult;
       } else {
-        // defaultCommand なし or root 以外 or 未マッチのコマンド名あり
-        // → 従来通りサブコマンド一覧ヘルプを表示
+        // defaultCommand なし or root 以外 → サブコマンド一覧ヘルプを表示
         const commandPath = extractPartialCommandPath(commandsDir, routeResult.stoppedDir);
         const helpText = generateSubcommandHelp({
           programName,

--- a/packages/fsss/tests/__fixtures__/commands/open.ts
+++ b/packages/fsss/tests/__fixtures__/commands/open.ts
@@ -1,0 +1,17 @@
+import { defineCommand } from "../../../src/index";
+import { z } from "zod";
+
+export default defineCommand({
+  description: "ファイルを開く",
+  args: {
+    path: {
+      type: z.string(),
+      positional: true,
+      description: "対象パス",
+      default: ".",
+    },
+  },
+  run({ args }) {
+    console.log(args.path);
+  },
+});

--- a/packages/fsss/tests/__fixtures__/default-command-positional-entry.ts
+++ b/packages/fsss/tests/__fixtures__/default-command-positional-entry.ts
@@ -1,0 +1,10 @@
+import { join } from "node:path";
+import { createCLI } from "../../src/index";
+
+const cli = createCLI({
+  commandsDir: join(import.meta.dirname, "commands"),
+  name: "test-cli",
+  autoEnv: { prefix: "TEST" },
+  defaultCommand: "open",
+});
+await cli.run();

--- a/packages/fsss/tests/cli.test.ts
+++ b/packages/fsss/tests/cli.test.ts
@@ -3,6 +3,10 @@ import { resolve } from "node:path";
 
 const ENTRY = resolve(import.meta.dirname, "__fixtures__/cli-entry.ts");
 const DEFAULT_COMMAND_ENTRY = resolve(import.meta.dirname, "__fixtures__/default-command-entry.ts");
+const DEFAULT_COMMAND_POSITIONAL_ENTRY = resolve(
+  import.meta.dirname,
+  "__fixtures__/default-command-positional-entry.ts",
+);
 const CONFIG_PATH = resolve(import.meta.dirname, "__fixtures__/test-config.json");
 
 async function runCLI(
@@ -292,9 +296,10 @@ describe("defaultCommand", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("存在しないコマンドでサブコマンド一覧を表示する", async () => {
+  test("未マッチのトークンはデフォルトコマンドにフォールバックする", async () => {
+    // serve には positional 引数がないため、未マッチトークンは無視されデフォルト値で実行される
     const { stdout, exitCode } = await runDefaultCLI("nonexistent");
-    expect(stdout).toContain("Available commands:");
+    expect(stdout).toBe("localhost:3000");
     expect(exitCode).toBe(0);
   });
 
@@ -321,6 +326,43 @@ describe("defaultCommand", () => {
     const { stdout, exitCode } = await runDefaultCLI("serve", "--help");
     expect(stdout).toContain("Usage: test-cli serve");
     expect(stdout).not.toContain("Available commands:");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// --- defaultCommand（positional 引数付き） ---
+
+async function runDefaultPositionalCLI(
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", "run", DEFAULT_COMMAND_POSITIONAL_ENTRY, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+describe("defaultCommand with positional args", () => {
+  test("未マッチのトークンをデフォルトコマンドの位置引数として渡す", async () => {
+    const { stdout, exitCode } = await runDefaultPositionalCLI("/tmp/foo");
+    expect(stdout).toBe("/tmp/foo");
+    expect(exitCode).toBe(0);
+  });
+
+  test("引数なしでデフォルトコマンドを実行する", async () => {
+    const { stdout, exitCode } = await runDefaultPositionalCLI();
+    expect(stdout).toBe(".");
+    expect(exitCode).toBe(0);
+  });
+
+  test("別コマンドの実行に影響しない", async () => {
+    const { stdout, exitCode } = await runDefaultPositionalCLI("config", "set", "foo", "bar");
+    expect(stdout).toBe("foo=bar");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## 概要

`defaultCommand` 設定時、ルータでマッチしなかったトークンをデフォルトコマンドの位置引数として渡すようにする。

Resolves #51

## 背景

`defaultCommand: "open"` のように positional 引数を持つコマンドをデフォルトに設定した場合、`orkis /tmp/foo` のような実行で `/tmp/foo` がサブコマンド名として解釈され、マッチしないためヘルプが表示されてしまう問題があった。

原因は `cli.ts` の `hasUnmatchedCommand` ガードで、先頭トークンがフラグ（`-` 始まり）でない場合に defaultCommand へのフォールバックをスキップしていたこと。

## 変更内容

- `cli.ts`: `hasUnmatchedCommand` ガードを除去し、ルートレベルで未解決の場合は常に defaultCommand にフォールバックする
- テスト: positional 引数付きコマンド (`open`) のフィクスチャを追加し、未マッチトークンが位置引数として渡されるケースを検証

## 確認事項

- [ ] `orkis /tmp/foo` 相当のケースで位置引数として渡されること
- [ ] 既存サブコマンド（`config` 等）の実行に影響がないこと
- [ ] `--help` 表示が正常に動作すること