### PR TITLE
chore: release v0.3.2

### DIFF
--- a/packages/fsss/package.json
+++ b/packages/fsss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/fsss",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A CLI framework where your file structure becomes your command structure, and a single schema gives you typed values whether they come from flags, env vars, or config files.",
   "type": "module",
   "author": "miyaoka",


### PR DESCRIPTION
## 概要

`@miyaoka/fsss` パッケージのバージョンを `0.3.1` → `0.3.2` に更新する。

## 背景

v0.3.2 のリリースに伴うバージョンバンプ。

## 変更内容

### バージョン更新

- `packages/fsss/package.json` の `version` フィールドを `0.3.2` に更新

## 確認事項

- [ ] npm publish が正常に行えること