### PR TITLE
fix(codegen): add export {} to plugin-less extensions.d.ts

### DIFF
--- a/packages/fsss/src/codegen.ts
+++ b/packages/fsss/src/codegen.ts
@@ -60,7 +60,7 @@ async function extractInterfaceNames(filePath: string): Promise<string[]> {
 }
 
 // .fsss/extensions.d.ts を生成する
-async function generateExtensionsType(commandsDir: string, outDir: string): Promise<void> {
+export async function generateExtensionsType(commandsDir: string, outDir: string): Promise<void> {
   const pluginFiles = await findAllPluginFiles(commandsDir);
 
   const typeInfos: PluginTypeInfo[] = [];
@@ -80,6 +80,8 @@ async function generateExtensionsType(commandsDir: string, outDir: string): Prom
 
   if (typeInfos.length === 0) {
     lines.push(
+      "",
+      "export {};",
       "",
       'declare module "@miyaoka/fsss" {',
       "  // eslint-disable-next-line @typescript-eslint/no-empty-object-type",
@@ -112,16 +114,18 @@ async function generateExtensionsType(commandsDir: string, outDir: string): Prom
 }
 
 // CLI として実行された場合
-const { values } = parseArgs({
-  options: {
-    commandsDir: { type: "string" },
-    outDir: { type: "string" },
-  },
-});
+if (import.meta.main) {
+  const { values } = parseArgs({
+    options: {
+      commandsDir: { type: "string" },
+      outDir: { type: "string" },
+    },
+  });
 
-if (values.commandsDir === undefined || values.outDir === undefined) {
-  console.error("Usage: bun run codegen.ts --commandsDir <path> --outDir <path>");
-  process.exit(1);
+  if (values.commandsDir === undefined || values.outDir === undefined) {
+    console.error("Usage: bun run codegen.ts --commandsDir <path> --outDir <path>");
+    process.exit(1);
+  }
+
+  await generateExtensionsType(values.commandsDir, values.outDir);
 }
-
-await generateExtensionsType(values.commandsDir, values.outDir);

--- a/packages/fsss/tests/__fixtures__/codegen-no-plugins/commands/hello.ts
+++ b/packages/fsss/tests/__fixtures__/codegen-no-plugins/commands/hello.ts
@@ -1,0 +1,1 @@
+export default { run() {} };

--- a/packages/fsss/tests/__fixtures__/codegen-with-plugins/commands/_plugins/logger.ts
+++ b/packages/fsss/tests/__fixtures__/codegen-with-plugins/commands/_plugins/logger.ts
@@ -1,0 +1,3 @@
+export interface LoggerExtension {
+  logger: { info(msg: string): void };
+}

--- a/packages/fsss/tests/codegen.test.ts
+++ b/packages/fsss/tests/codegen.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { generateExtensionsType } from "../src/codegen";
+
+const FIXTURES_DIR = resolve(import.meta.dirname, "__fixtures__");
+
+describe("generateExtensionsType", () => {
+  const tmpOutDirs: string[] = [];
+
+  function createOutDir(name: string): string {
+    const dir = join(FIXTURES_DIR, name, ".codegen-out");
+    tmpOutDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    for (const dir of tmpOutDirs) {
+      await rm(dir, { recursive: true, force: true });
+    }
+    tmpOutDirs.length = 0;
+  });
+
+  test("プラグインなしで export {} を含むモジュールファイルを生成する", async () => {
+    const commandsDir = join(FIXTURES_DIR, "codegen-no-plugins", "commands");
+    const outDir = createOutDir("codegen-no-plugins");
+
+    await generateExtensionsType(commandsDir, outDir);
+
+    const content = await readFile(join(outDir, "extensions.d.ts"), "utf-8");
+    expect(content).toContain("export {};");
+    expect(content).toContain('declare module "@miyaoka/fsss"');
+    expect(content).toContain("interface Extensions {}");
+    expect(content).not.toContain("import type");
+  });
+
+  test("プラグインありで import type を含むファイルを生成する", async () => {
+    const commandsDir = join(FIXTURES_DIR, "codegen-with-plugins", "commands");
+    const outDir = createOutDir("codegen-with-plugins");
+
+    await generateExtensionsType(commandsDir, outDir);
+
+    const content = await readFile(join(outDir, "extensions.d.ts"), "utf-8");
+    expect(content).toContain("import type { LoggerExtension }");
+    expect(content).toContain("interface Extensions extends LoggerExtension {}");
+    expect(content).not.toContain("export {};");
+  });
+});


### PR DESCRIPTION
## 概要

`fsss-codegen` がプラグインなしで生成する `extensions.d.ts` に `export {}` を追加し、ambient module declaration ではなく module augmentation として正しく動作するようにする。

## 背景

プラグインのないプロジェクトで `fsss-codegen` を実行すると、生成される `extensions.d.ts` に `import` も `export` も含まれないため、TypeScript がファイルを「スクリプト」として扱う。結果として `declare module "@miyaoka/fsss"` が ambient module declaration（モジュール全体の再定義）になり、`createCLI` や `defineCommand` などの本来の export が見えなくなる。

プラグインがある場合は `import type` が生成されるため問題にならない。

関連: #181

## 変更内容

### 生成ロジックの修正

- プラグインなしの場合に `export {};` を出力するよう変更
- `generateExtensionsType` を export してテスト可能に
- CLI エントリポイントを `import.meta.main` でガードし、import 時にトップレベルコードが実行されないように

### テスト追加

- `codegen.test.ts` を新規作成（プラグインなし・ありの 2 ケース）
- プラグインなし・ありの fixture ディレクトリを追加

## 確認事項

- [ ] プラグインなしの examples/minimal で型エラーが発生しないこと
- [ ] プラグインありの examples/full で既存動作に影響がないこと
