### PR TITLE
fix(release-notes): exclude renovate bot by author in addition to label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,5 @@ changelog:
   exclude:
     labels:
       - dependencies
+    authors:
+      - renovate[bot]


### PR DESCRIPTION
## 概要

GitHub 自動生成リリースノートで renovate bot の PR を著者ベースでも除外するようにした。

## 背景

v0.5.0 のリリースノートに renovate bot の PR（ #101 , #144 ）が含まれていた。`.github/release.yml` で `dependencies` ラベルによる除外を設定していたが、renovate がラベルを付け忘れるケースがあり、ラベルのみの除外では不十分だった。

## 変更内容

### リリースノート設定

- `exclude.authors` に `renovate[bot]` を追加し、ラベルの有無に関わらず renovate bot の PR を除外

## 確認事項

- [ ] 次回リリースノート生成時に renovate の PR が含まれないことを確認
