### PR TITLE
fix(deps): move zod to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 >
 > _A CLI framework where your file structure becomes your command structure, and a single schema gives you typed values whether they come from flags, env vars, or config files._
 
+## Install
+
+`zod` を peer dependency として要求するため、本体と一緒にインストールする。
+
+```sh
+pnpm add @miyaoka/fsss zod
+```
+
 ## File Structure — ファイルを置くだけでコマンドが生える
 
 ```

--- a/packages/fsss/package.json
+++ b/packages/fsss/package.json
@@ -43,8 +43,8 @@
     "lint": "oxlint --type-aware .",
     "fix": "oxlint --type-aware --fix . && oxfmt ."
   },
-  "dependencies": {
-    "zod": "catalog:"
+  "peerDependencies": {
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@tsconfig/node24": "catalog:",
@@ -54,6 +54,7 @@
     "oxlint-tsgolint": "catalog:",
     "typescript": "catalog:",
     "unplugin-dts": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,10 +157,6 @@ importers:
         version: 6.0.3
 
   packages/fsss:
-    dependencies:
-      zod:
-        specifier: 'catalog:'
-        version: 4.3.6
     devDependencies:
       '@tsconfig/node24':
         specifier: 'catalog:'
@@ -186,6 +182,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
 packages:
 


### PR DESCRIPTION
## 概要

`packages/fsss` の `zod` を `dependencies` から `peerDependencies` に移し、利用側がインストールしている zod 実体を共有するように変更します。あわせて README に Install セクションを新設し、 zod の同時インストールが必要な旨を明示します。

## 背景

`@miyaoka/fsss@0.5.0` の `package.json` では `dependencies.zod` に catalog 経由で `4.3.6` を pin していました。利用側で `zod@4.4.2` に上げたところ、 fsss が抱える `4.3.6` と利用側の `4.4.2` が pnpm 上で別実体として解決され、 `defineCommand` の `args.type` に `z.string()` を渡しただけで TS2322 になる事象が発生しました ( #185 )。

zod v4 は `ZodType` の internals に `version.minor` リテラル ( `3` / `4` ) を埋めているため、マイナーバージョンが揃わない限り型レベルで非互換となります。 fsss は利用側が定義した zod スキーマをそのまま受け取って実行・型推論する API なので、実体を共有する peer dep として宣言するのが本来正しい形でした。

peer dep 化に伴い新規利用者は `pnpm add @miyaoka/fsss` だけでは zod を取得できなくなるため、 README に Install セクションを追加して手順を明示します。

## 変更内容

### packages/fsss

- `dependencies.zod` を削除し `peerDependencies.zod: "^4.0.0"` を追加
- ローカルでのビルド・型解決のために `devDependencies.zod: "catalog:"` を追加
- `pnpm-lock.yaml` を再生成

### README

- 冒頭説明と File Structure セクションの間に Install セクションを新設
- `pnpm add @miyaoka/fsss zod` を提示し、 zod が peer として要求される旨を記載

## スコープ

- **スコープ内**: fsss 本体の zod 依存宣言の修正と、それに伴う Install 手順の追記
- **スコープ外（対応しない）**: peer の許容範囲を v4 系列より狭める対応。 zod 側で再びマイナー単位の型互換性が崩れた場合は上流の問題として扱い、利用側のアップグレード経路を塞がないようにします

## 確認事項

- [ ] `pnpm typecheck:all` / `pnpm test:all` / `pnpm lint:all` が通ること
- [ ] 公開後、利用側 ( zod を `4.4.x` などに固定したリポジトリ ) で `defineCommand` の型エラーが解消されること
- [ ] 新規利用者が README の Install 手順だけで動作する状態に到達できること
