### PR TITLE
chore: release v0.6.0

### DIFF
--- a/packages/fsss/package.json
+++ b/packages/fsss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miyaoka/fsss",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A CLI framework where your file structure becomes your command structure, and a single schema gives you typed values whether they come from flags, env vars, or config files.",
   "type": "module",
   "author": "miyaoka",


### PR DESCRIPTION
## 概要

`@miyaoka/fsss` を v0.5.0 から v0.6.0 へバージョンアップする。

## 背景

v0.5.0 以降、利用者向けの install 手順に影響する変更が入った。

- `zod` を `dependencies` から `peerDependencies` (`^4.0.0`) に移動。利用側で `zod` の明示インストールが必須になる
- README に Install セクションを追加し `pnpm add @miyaoka/fsss zod` を案内
- `.github/release.yml` の changelog 除外設定に `renovate[bot]` を author として追加
- pnpm を 11.0.6 へ更新

`zod` の peer 化は利用側の install コマンドが変わる破壊的変更だが、0.x 系のため SemVer の慣習に従い minor bump (0.5.0 → 0.6.0) で対応する。

## 変更内容

### バージョン

- `packages/fsss/package.json` を 0.6.0 に更新
- タグ `v0.6.0` を作成

## 確認事項

- [ ] CI が green であること
- [ ] マージ後に GitHub Release を作成し、`publish.yml` が npm publish を実行すること
