### PR TITLE
chore(renovate): 共有プリセットを導入して renovate.json を薄くする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":pinDependencies"],
+  "extends": [
+    "config:best-practices",
+    ":pinDependencies",
+    "github>miyaoka/renovate-config"
+  ],
   "labels": ["dependencies"],
   "assignees": ["miyaoka"],
-  "reviewers": ["miyaoka"],
-  "packageRules": [
-    {
-      "description": "auto-merge tsgo dev preview daily releases",
-      "matchPackageNames": ["@typescript/native-preview"],
-      "automerge": true
-    }
-  ]
+  "reviewers": ["miyaoka"]
 }


### PR DESCRIPTION
## 概要

`renovate.json` の `extends` に共有プリセット `github>miyaoka/renovate-config` を追加し、リポジトリ固有でベタ書きしていた tsgo（`@typescript/native-preview`）の automerge `packageRules` を削除した。tsgo の automerge ルールは共有プリセット側に存在するため、本ファイルでの重複定義をやめてプリセットに一本化する。

## 背景

これまで `renovate.json` は tsgo dev preview を日次 automerge する `packageRules` を個別に持っていた。この automerge ルールは共有プリセット `github>miyaoka/renovate-config` にも定義されており、本ファイルでの定義はそれと重複していた。プリセットを継承すれば tsgo automerge はそちらから供給されるため、本ファイルの `packageRules` を削除して定義元をプリセットに一本化する。

`extends` は配列の後方が優先されてマージされる（スカラ/オブジェクトは後方優先の deep merge）。`labels` / `assignees` / `reviewers` はプリセットに存在せず衝突しないため本ファイルに残し、これまで通り機能する。`packageRules` はマージではなく連結されるが、本ファイルから削除したことで連結対象はプリセット側のみとなり、tsgo automerge が正しく効く。

## 変更内容

### renovate

- `extends` 末尾に `github>miyaoka/renovate-config` を追加
- tsgo `@typescript/native-preview` の automerge `packageRules` を削除（定義元を共有プリセットに一本化）

## 確認事項

- [x] 共有プリセット `github>miyaoka/renovate-config`（`default.json`）に tsgo（`@typescript/native-preview`）の automerge 相当ルールが存在することを確認済み
